### PR TITLE
Jessie update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ and on top of that:
    
    - Installed from package management. See /var/www for links to file
      paths.
-   - Supports Git, Mercurial and Subversion (Bazzar no longer supported).
+   - Supports Git, Mercurial and Subversion (Bazaar no longer supported).
    - List repositories in web interface.
    - Example helloworld repositories.
    - Site wide authentication realm and admin user.

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ and on top of that:
    
    - Installed from package management. See /var/www for links to file
      paths.
-   - Supports Git, Bazaar, Mercurial and Subversion.
+   - Supports Git, Mercurial and Subversion (Bazzar no longer supported).
    - List repositories in web interface.
    - Example helloworld repositories.
    - Site wide authentication realm and admin user.
@@ -31,7 +31,6 @@ and on top of that:
     Name        Protocol access
     ----        ---------------
     Git         git://addr/git/REPO
-    Bazaar      bzr://addr/bzr/REPO
     Subversion  svn://addr/svn/REPO
     Mercurial   http://addr:8080/REPO
     Repositories are stored in /srv/repos.

--- a/changelog
+++ b/changelog
@@ -2,7 +2,7 @@ turnkey-trac-14.0 (1) turnkey; urgency=low
 
   * Latest Debian Jessie package version of Trac and related packages.
 
-  * BZR support removed (trac-bzr plugin no longer maintained).
+  * Bazaar support removed (trac-bzr plugin no longer maintained).
 
   * Note: Please refer to turnkey-core's changelog for changes common to all
     appliances. Here we only describe changes specific to this appliance.

--- a/changelog
+++ b/changelog
@@ -1,3 +1,14 @@
+turnkey-trac-14.0 (1) turnkey; urgency=low
+
+  * Latest Debian Jessie package version of Trac and related packages.
+
+  * BZR support removed (trac-bzr plugin no longer maintained).
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Tue, 07 Jul 2015 17:16:06 +1000
+
 turnkey-trac-13.0 (1) turnkey; urgency=low
 
   * Latest Debian Wheezy package version of Trac and related packages.

--- a/conf.d/main
+++ b/conf.d/main
@@ -17,7 +17,6 @@ ln -s $TRAC_SHARE /var/www/backend
 
 # create example projects
 trac-initproject git helloworld
-trac-initproject bzr helloworld
 trac-initproject svn helloworld
 trac-initproject hg helloworld
 
@@ -55,3 +54,6 @@ a2dissite 000-default
 ln -s $TRAC_ETC/apache.conf /etc/apache2/sites-available/trac.conf
 a2ensite trac
 
+#removed bzr as no longer supported
+apt-get -y purge bzr python-bzrlib python-paramiko
+rm -rf /etc/init.d/bzr /srv/repos/bzr

--- a/conf.d/main
+++ b/conf.d/main
@@ -51,7 +51,7 @@ mv $TRAC_ETC/HttpHostLink.py $TRAC_SHARE/plugins
 chown -R www-data:www-data $TRAC_SHARE/plugins
 
 # configure apache
-a2dissite default
-ln -s $TRAC_ETC/apache.conf /etc/apache2/sites-available/trac
+a2dissite 000-default
+ln -s $TRAC_ETC/apache.conf /etc/apache2/sites-available/trac.conf
 a2ensite trac
 

--- a/overlay/etc/trac/apache.conf
+++ b/overlay/etc/trac/apache.conf
@@ -1,5 +1,4 @@
-NameVirtualHost *:80
-NameVirtualHost *:443
+ServerName localhost
 
 <VirtualHost *:80>
     UseCanonicalName Off
@@ -18,8 +17,7 @@ WSGIScriptAlias / /usr/local/share/trac/cgi-bin/trac.wsgi
 
 <Directory /usr/local/share/trac/htdocs>
     WSGIApplicationGroup %{GLOBAL}
-    Order deny,allow
-    Allow from all
+    Require all granted
 </Directory>
 
 <LocationMatch "/[^/]+/login">

--- a/overlay/etc/trac/apache.conf
+++ b/overlay/etc/trac/apache.conf
@@ -20,6 +20,10 @@ WSGIScriptAlias / /usr/local/share/trac/cgi-bin/trac.wsgi
     Require all granted
 </Directory>
 
+<Directory /usr/local/share/trac/cgi-bin>
+    Require all granted
+ </Directory>
+
 <LocationMatch "/[^/]+/login">
     AuthType Basic
     AuthName "Trac"

--- a/overlay/usr/local/bin/trac-initproject
+++ b/overlay/usr/local/bin/trac-initproject
@@ -43,7 +43,7 @@ init_trac_project() {
 }
 
 if [ $# -ne "2" ]; then
-    echo "Syntax:  $0 git|bzr|svn|hg NAME"
+    echo "Syntax:  $0 git|svn|hg NAME"
     echo "Example: $0 git foobar"
     echo 
     echo "Environment variables:"
@@ -97,19 +97,7 @@ case "$VC" in
         sed -i "s/^repository_dir =\(.*\)/repository_dir = $(esc $GIT_REPO)/" $INI
         sed -i "s/^git_bin = \(.*\)/git_bin = $(esc /usr/bin/git)/" $INI
         echo "[components]" >> $INI
-        echo "tracext.git.* = enabled" >> $INI
-        ;;
-    bzr)
-        # initialize empty repository
-        mkdir -p $PROJ_REPO
-        cd $PROJ_REPO
-        [ -d ".bzr" ] || bzr init-repository .
-
-        # initialize trac project
-        init_trac_project
-        INI=$TRAC_ETC/$VC-$NAME.ini
-        echo "[components]" >> $INI
-        echo "tracbzr.* = enabled" >> $INI
+        echo "tracopt.versioncontrol.git.* = enabled" >> $INI
         ;;
     hg)
         # initialize empty repository
@@ -127,9 +115,12 @@ case "$VC" in
         # initialize empty repository
         mkdir -p $PROJ_REPO
         [ -e "$PROJ_REPO/conf/svnserve.conf" ] || svnadmin create $PROJ_REPO
-
+        
         # initialize trac project
         init_trac_project
+        INI=$TRAC_ETC/$VC-$NAME.ini
+        echo "[components]" >> $INI
+        echo "tracopt.versioncontrol.svn.* = enabled" >> $INI
         ;;
     *)
         fatal "unsupported VC: $VC"

--- a/overlay/usr/local/bin/trac-initproject
+++ b/overlay/usr/local/bin/trac-initproject
@@ -79,7 +79,7 @@ case "$VC" in
         [ -d ".git" ] || git init
 
         touch $PROJ_REPO/.git/git-daemon-export-ok
-        ln -s $PROJ_REPO/.git /var/cache/git/$NAME.git
+        ln -s $PROJ_REPO/.git /var/lib/git/$NAME.git
         echo $name > $PROJ_REPO/.git/description
 
         # allow public git-push to repo
@@ -93,7 +93,7 @@ case "$VC" in
         # initialize trac project
         init_trac_project
         INI=$TRAC_ETC/$VC-$NAME.ini
-        GIT_REPO=/var/cache/git/$NAME.git
+        GIT_REPO=/var/lib/git/$NAME.git
         sed -i "s/^repository_dir =\(.*\)/repository_dir = $(esc $GIT_REPO)/" $INI
         sed -i "s/^git_bin = \(.*\)/git_bin = $(esc /usr/bin/git)/" $INI
         echo "[components]" >> $INI

--- a/plan/main
+++ b/plan/main
@@ -6,8 +6,8 @@ libapache2-mod-wsgi
 webmin-apache
 
 trac
-trac-git
-trac-bzr
+//trac-git
+//trac-bzr
 trac-mercurial
 
 libjs-jquery            /* required for trac-admin deploy */

--- a/plan/main
+++ b/plan/main
@@ -6,8 +6,6 @@ libapache2-mod-wsgi
 webmin-apache
 
 trac
-//trac-git
-//trac-bzr
 trac-mercurial
 
 libjs-jquery            /* required for trac-admin deploy */


### PR DESCRIPTION
Bazaar is no longer supported by Trac (plugin no longer maintained). Support for other VCS remains unchanged. Git has become part of Trac core.

As I only removed bzr, I kept this based on the revision control appliance and just removed Bazaar/bzr components from this appliance.