### PR TITLE
Update for v14.1

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -6,6 +6,7 @@ ADMIN_PASS=turnkey
 TRAC_ETC=/etc/trac
 TRAC_LIB=/var/local/lib/trac
 TRAC_SHARE=/usr/local/share/trac
+export PKG_RESOURCES_CACHE_ZIP_MANIFESTS=1
 
 mkdir -p $TRAC_LIB
 

--- a/overlay/usr/local/bin/trac-initproject
+++ b/overlay/usr/local/bin/trac-initproject
@@ -25,8 +25,8 @@ init_trac_project() {
     trac-admin $PROJ_LIB config set header_logo height 73
     trac-admin $PROJ_LIB config set header_logo link "$PROJ"
     trac-admin $PROJ_LIB config set header_logo width 236
-    trac-admin $PROJ_LIB config set header_logo src $(esc site/logo.png)
-    trac-admin $PROJ_LIB config set project icon $(esc images/$VC.png)
+    trac-admin $PROJ_LIB config set header_logo src "site/logo.png"
+    trac-admin $PROJ_LIB config set project icon "images/$VC.png"
     trac-admin $PROJ_LIB config set project descr "$PROJ_DESC"
     trac-admin $PROJ_LIB config set notification smtp_enabled true
     trac-admin $PROJ_LIB config set notification smtp_replyto root@localhost
@@ -91,8 +91,8 @@ case "$VC" in
         # initialize trac project
         init_trac_project
         GIT_REPO=/var/lib/git/$NAME.git
-        trac-admin $PROJ_LIB config set trac repository_dir $(esc $GIT_REPO)
-        trac-admin $PROJ_LIB config set trac git_bin $(esc /usr/bin/git)
+        trac-admin $PROJ_LIB config set trac repository_dir "$GIT_REPO"
+        trac-admin $PROJ_LIB config set trac git_bin "/usr/bin/git"
         trac-admin $PROJ_LIB config set components tracopt.versioncontrol.git.* enabled
         ;;
     hg)
@@ -103,7 +103,7 @@ case "$VC" in
 
         # initialize trac project
         init_trac_project
-        trac-admin config set components tracext.hg.* enabled
+        trac-admin $PROJ_LIB config set components tracext.hg.* enabled
         ;;
     svn)
         # initialize empty repository

--- a/overlay/usr/local/bin/trac-initproject
+++ b/overlay/usr/local/bin/trac-initproject
@@ -6,10 +6,6 @@ fatal() {
     exit 1
 }
 
-esc() {
-    echo $1 | sed "s#\/#\\\\\/#g"
-}
-
 init_trac_project() {
     echo "initializing trac project: $VC"
 


### PR DESCRIPTION
Reduce warnings during build time (to make it easier to read).

Also fixed trac-initproject:
-fixed missing trac-admin argument from hg repo creation (ln 106)
-removed escaping of paths as not required now (IIRC that was for the sed commands that were used prior to the usage of trac-admin?). TBH I'm not sure if the quotes are really required but they don't hurt... I also removed the esc function as it's now no longer used.